### PR TITLE
switch to for range over channels instead of select. unbuffer channels

### DIFF
--- a/charts/pinot-exporter/templates/deployment.yaml
+++ b/charts/pinot-exporter/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ .Values.listenPort }}
               protocol: TCP
           volumeMounts:
             - name: config

--- a/pinotexporter.yaml
+++ b/pinotexporter.yaml
@@ -1,6 +1,6 @@
 ---
 port: 8088 # default is 8080
-mode: kubernetes
+mode: direct
 serviceDiscovery:
   labelSelector:
     app: pinot

--- a/sd_kubernetes.go
+++ b/sd_kubernetes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -106,6 +107,8 @@ func GetLabelSelectorString(labels map[string]string) string {
 	for labelName, labelValue := range labels {
 		pairs = append(pairs, labelName+"="+labelValue)
 	}
+	// Sort pairs to get consistent strings.
+	slices.Sort(pairs)
 	selector = strings.Join(pairs, ",")
 	return selector
 

--- a/table_cache.go
+++ b/table_cache.go
@@ -27,21 +27,11 @@ func refreshTableCache(ctx context.Context, controller *PinotController, sleepDu
 
 // Refresh the table cache when we get a new list from the re
 func (t *TableCache) TableRefreshChanListener(tables <-chan []string) {
-	for {
-		select {
-		case newTables, chanIsOpen := <-tables:
-			{
-				if !chanIsOpen {
-					//cleanup and return
-					return
-				}
-				fmt.Printf("TableCache received update: %+v\n", newTables)
-				t.mutex.Lock()
-				t.Tables = newTables
-				t.mutex.Unlock()
-			}
-		default:
-		}
+	for newTables := range tables {
+		fmt.Printf("TableCache received update: %+v\n", newTables)
+		t.mutex.Lock()
+		t.Tables = newTables
+		t.mutex.Unlock()
 	}
 }
 

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTableRefreshChanListener(t *testing.T) {
-	tables := make(chan []string, 1)
+	tables := make(chan []string)
 
 	var cache TableCache
 


### PR DESCRIPTION
Switches from `for{ select {} } `  to `for := range channelname` 
It also unbuffers channels as they did not need it.

This fixes a bug where for select would cause very high CPU usage.